### PR TITLE
hashowania przy zmianie i user req poprawa

### DIFF
--- a/aiim_project/app/Http/Controllers/RestApiUserController.php
+++ b/aiim_project/app/Http/Controllers/RestApiUserController.php
@@ -84,7 +84,7 @@ class RestApiUserController extends Controller
             'nickname' => $request->nickname,
             'email' => $request->email,
             'index' => $request->index,
-            'password' => Hash::make($request->password), // <- zmienić na hash kiedy dojdzie do wyjscia
+            'password' => Hash::make($request->password),
             //'password' => $request->password,
             'account_type' => 'U',
         ]);
@@ -120,7 +120,7 @@ class RestApiUserController extends Controller
             $user->nickname = $data['nickname'];
             $user->index = $data['index'];
             $user->email = $data['email'];
-            $user->password = $data['password'];
+            $user->password = Hash::make($data['password']);
             $user->account_type = $data['account_type'];
             $user->save();
             return response()->json(['data' => $user, 'message'=>$message]);
@@ -134,7 +134,7 @@ class RestApiUserController extends Controller
         $data = $request->validated(); // <- do edycji validacja, pozwalająca na zmiane pojedyńczych danych
         $user = User::find($id);
         if($user != null){
-            $user->password = $data['password'];
+            $user->password = Hash::make($data['password']);
             $user->save();
             return response()->json(['data' => $user, 'message'=>$message]);
         } else

--- a/aiim_project/app/Http/Requests/UserRequest.php
+++ b/aiim_project/app/Http/Requests/UserRequest.php
@@ -74,7 +74,11 @@ class UserRequest extends FormRequest
     public function update()
     {
         return [
-            'password'     => 'required|String|min:6'
+            'nickname'     => 'String|min:3|max:25',
+            'index'        => 'String|min:5|max:6',
+            'email'        => 'String|min:3',
+            'password'     => 'required|String|min:6',
+            'account_type' => 'String|max:1'
         ];
     }
 


### PR DESCRIPTION
Dodałem hashowanie przy zmianie hasła przez /update/password/ i /update/all/ (powodowało brak możliwości zalogowania na konto z zmienionymi danymi) , a także w user request przy update dodałem dane, w celu wyeliminowania błędu walidacji. 