### PR TITLE
Dodanie endpointu do wysłania powiadomienia o zamknięciu chatu

### DIFF
--- a/aiim_project/app/Http/Controllers/RestApiChatController.php
+++ b/aiim_project/app/Http/Controllers/RestApiChatController.php
@@ -2,9 +2,51 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Guide;
+use App\Models\User;
+use App\Notifications\CloseChatNotification;
 use Illuminate\Http\Request;
+use App\Models\Chat;
+use Illuminate\Support\Carbon;
 
 class RestApiChatController extends Controller
 {
-    //
+    public function askToCloseChat(int $chatID){
+        $chatToClose = Chat::find($chatID);
+
+        if ($chatToClose === null) {
+            return response()
+            ->json(['message' => "Chat nie istnieje!"])
+            ->setStatusCode(404);
+        }
+
+        $current_date = Carbon::now();
+        $editDate = Carbon::parse(date('Y-m-d', strtotime($chatToClose->edited_at))); 
+        $diffDays = $editDate->diffInDays($current_date);
+
+        if ($diffDays > 3) {
+
+            $questioner = User::find($chatToClose->id_user);
+
+            if ($questioner == null) {
+                return response()
+                    ->json(['message' => 'Użytkownik nie istnieje!'])
+                    ->setStatusCode(404);
+            }
+            
+            $guide = Guide::find($chatToClose->id_guide);
+    
+            if ($guide == null) {
+                return response()
+                    ->json(['message' => 'Wolontariusz nie istnieje!'])
+                    ->setStatusCode(404);
+            }
+            
+            $questioner->notify(new CloseChatNotification());
+            $guide->notify(new CloseChatNotification);
+
+            return response()->setStatusCode(200);
+    
+        }
+    }
 }

--- a/aiim_project/app/Models/Notification.php
+++ b/aiim_project/app/Models/Notification.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Notification extends Model
+{
+    use HasFactory;
+}

--- a/aiim_project/app/Notifications/CloseChatNotification.php
+++ b/aiim_project/app/Notifications/CloseChatNotification.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class CloseChatNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail','database'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    ->subject("Zamknięcie czatu")
+                    ->greeting("Witaj!")
+                    ->lines([
+                        "Zauważyliśmy, że czat, którego jesteś użytkownikiem był nieaktywny od 3 dni",
+                        "Czy uzyskałeś/aś odpowiednią odpowiedź i chciałbyś/chciałabyś zamknąć czat?",
+                        "Jeżeli tak, to skorzystaj z linku poniżej aby zamknąć chat:"
+                    ])
+                    ->action('Zamknięcie czatu', url('/api/close'));
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toDatabase($notifiable)
+    {
+        return [
+            'message' => 'Czy chcesz zamknąć czat?',
+            'action' => 'close-chat',
+        ];
+    }
+
+    
+}

--- a/aiim_project/database/migrations/2023_10_04_100739_create_notifications_table.php
+++ b/aiim_project/database/migrations/2023_10_04_100739_create_notifications_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateNotificationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('body');
+            $table->integer('user_id');
+            $table->boolean('read')->default(false);
+            $table->timestamp("created_at");
+        });
+    }
+
+    /**
+      * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('notifications');
+    }
+}

--- a/aiim_project/routes/api.php
+++ b/aiim_project/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\RestApiNoticeBoardController;
 use App\Http\Controllers\RestApiCommentController;
 use App\Http\Controllers\RestApiQnACommentController;
 use App\Http\Controllers\RestApiQnAController;
+use App\Http\Controllers\RestApiChatController;
 
 /*
 |--------------------------------------------------------------------------
@@ -52,3 +53,5 @@ Route::patch('/qna/{id}',[RestApiQnAController::class, 'editQuestion']);
 Route::delete('/qna/{id}', [RestApiQnAController::class, 'deleteQuestion']);
 
 Route::patch('/qna/comments/{id}', [RestApiQnACommentController::class, "editActiveComment"]);
+
+Route::get('/chats/askToClose/{id}',[RestApiChatController::class,'askToCloseChat']);


### PR DESCRIPTION
Niestety nie miałem jak sprawdzić tego endpointa, ponieważ wygasło konto na Foce:
![image](https://github.com/magdadobek/AIIM1Project/assets/30226946/173c5a1c-b0a2-46b7-8ce4-71af4094373e)

![image](https://github.com/magdadobek/AIIM1Project/assets/30226946/41de79ab-59bc-4076-add1-03cb843cb53f)


Dodatkowo, żeby ten endpoint działał poprawnie, potrzebny jest endpoint do zamykania chatów.