### PR TITLE
endpoint zmiany account type i zabezpieczenie mininimalne user endpointów

### DIFF
--- a/aiim_project/routes/api.php
+++ b/aiim_project/routes/api.php
@@ -36,6 +36,7 @@ Route::post('/user/refresh',[RestApiUserController::class,'refreshUser']);
 Route::delete('/user/delete/{id}', [RestApiUserController::class, 'DeleteUser']);
 Route::patch('/user/update/all/{id}', [RestApiUserController::class, 'UpdateUserAll']);
 Route::patch('/user/update/password/{id}', [RestApiUserController::class, 'UpdateUserPassword']);
+Route::patch('/user/update/accountType/{id}', [RestApiUserController::class, 'UpdateAccountType']);
 Route::get('/user/find/{id}', [RestApiUserController::class, 'FindUser']);
 
 Route::get('/noticeboard/allOpen', [RestApiNoticeBoardController::class, 'getAllOpenNoticeBoard']);

--- a/aiim_project/storage/api-docs/api-docs.json
+++ b/aiim_project/storage/api-docs/api-docs.json
@@ -444,6 +444,23 @@
                         }
                     }
                 ],
+                "requestBody": {
+                    "description": "User token",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "example": "*token*"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -465,6 +482,26 @@
                                                 "email": "",
                                                 "account_type": ""
                                             }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Błąd autoryzacji",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "error"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Błąd autoryzacji, token nieprawidłowy lub unieważniony"
                                         }
                                     },
                                     "type": "object"
@@ -498,7 +535,7 @@
                 ],
                 "summary": "Dodanie nowego użytkownika",
                 "requestBody": {
-                    "description": "Informacje o użytkowniku",
+                    "description": "Informacje o użytkowniku i token admina lub guida",
                     "required": true,
                     "content": {
                         "application/json": {
@@ -522,6 +559,11 @@
                                     "password": {
                                         "type": "string",
                                         "format": "password"
+                                    },
+                                    "token": {
+                                        "type": "string",
+                                        "format": "string",
+                                        "example": "*token*"
                                     }
                                 }
                             }
@@ -560,6 +602,26 @@
                                 }
                             }
                         }
+                    },
+                    "401": {
+                        "description": "Błąd autoryzacji",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "error"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Błąd autoryzacji, token nieprawidłowy lub unieważniony"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -583,7 +645,7 @@
                     }
                 ],
                 "requestBody": {
-                    "description": "User information",
+                    "description": "Dane użytkownika i token admina lub guida",
                     "required": true,
                     "content": {
                         "application/json": {
@@ -607,6 +669,11 @@
                                     "password": {
                                         "type": "string",
                                         "format": "password"
+                                    },
+                                    "token": {
+                                        "type": "string",
+                                        "format": "string",
+                                        "example": "*token*"
                                     }
                                 }
                             }
@@ -657,6 +724,26 @@
                             }
                         }
                     },
+                    "401": {
+                        "description": "Błąd autoryzacji",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "error"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Błąd autoryzacji, token nieprawidłowy lub unieważniony"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
                     "404": {
                         "description": "Brak użytkownika o podanym ID",
                         "content": {
@@ -666,6 +753,130 @@
                                         "message": {
                                             "type": "string",
                                             "example": "Użytkownik nie istnieje!"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/user/update/accountType/{id}": {
+            "patch": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Aktualizacja account_type użytkownika o podanym ID",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID użytkownika, dla którego aktualizujemy account_type",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Account_type żądany i token admina lub guida",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "format": "string",
+                                        "example": "*token*"
+                                    },
+                                    "account_type": {
+                                        "type": "string",
+                                        "format": "string",
+                                        "example": "G"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "object",
+                                            "format": "User",
+                                            "example": {
+                                                "id": "$id",
+                                                "nickname": "",
+                                                "index": "",
+                                                "email": "",
+                                                "account_type": ""
+                                            }
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Zaktualizowano account type uzytkownika o id: $id"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Zła walidacja",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Wrong account_type!"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Błąd autoryzacji",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "error"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Błąd autoryzacji, token nieprawidłowy lub unieważniony"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Brak użytkownika o podanym ID",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Brak użytkownika o tym podanym id"
                                         }
                                     },
                                     "type": "object"
@@ -793,6 +1004,23 @@
                         }
                     }
                 ],
+                "requestBody": {
+                    "description": "Admin token",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "example": "*token*"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -814,6 +1042,26 @@
                                                 "email": "",
                                                 "account_type": ""
                                             }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Błąd autoryzacji, zły token lub token nie admina",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "example": "error"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Błąd autoryzacji, token nieprawidłowy lub unieważniony"
                                         }
                                     },
                                     "type": "object"


### PR DESCRIPTION
Wprowadzenie endpointu do zmiany account type, może to zrobić osoba tylko z account tyoe albo guide albo admin, sprawdzane jest po tokenie, także do account type mozna wprowadzic tylko jedną litere, i musi się ona znajdować w body requesta

Zabezpieczyłem minimalnie endpointy usera:

- /api/user/find/{id} - wymaga user tokena, do dogadania czy do zmiany, ale endpoint zwraca za duzo danych jak na bez zabezpieczeń
- /api/user/new - wymaga tokena admina lub guida
- /api/user/update/all/{id} - wymaga tokena admina lub guida
- /api/user/delete/{id} - wymaga admin tokena

Wszystko zostało dodane do swaggera